### PR TITLE
fix: PR creation

### DIFF
--- a/.github/workflows/sync-dependabot-to-main.yml
+++ b/.github/workflows/sync-dependabot-to-main.yml
@@ -1,8 +1,8 @@
 name: Create PR to main from dependabot-integration
 
 on:
-  push:
-    branches: [ dependabot-integration ]
+  schedule:
+    - cron: '0 8 * * 1'  # Weekly on Mondays at 8:00 AM UTC
   workflow_dispatch:
 
 jobs:
@@ -41,7 +41,7 @@ jobs:
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           base: main
-          head: dependabot-integration
+          branch: dependabot-integration
           title: "Sync dependency updates from dependabot-integration to main"
           body: |
             ## Dependency Updates Sync

--- a/.github/workflows/sync-main-to-dependabot.yml
+++ b/.github/workflows/sync-main-to-dependabot.yml
@@ -3,7 +3,6 @@ name: Create PR to dependabot-integration from main
 on:
   push:
     branches: [ main ]
-  workflow_dispatch:
 
 jobs:
   create-pr-to-dependabot:
@@ -41,7 +40,7 @@ jobs:
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           base: dependabot-integration
-          head: main
+          branch: main
           title: "Sync main branch changes to dependabot-integration"
           body: |
             ## Main Branch Sync


### PR DESCRIPTION
 The issue was that the peter-evans/create-pull-request@v5 action doesn't accept a head parameter - it should be branch instead.
